### PR TITLE
pop is the official uri scheme for pop3

### DIFF
--- a/Firefox addon/KeeFox/chrome/content/commonDialog.js
+++ b/Firefox addon/KeeFox/chrome/content/commonDialog.js
@@ -313,7 +313,7 @@ var keeFoxDialogManager = {
                     this._imapBundleUsesStrings ? "imapEnterPasswordPromptTitle" : "5051",
                     this._imapBundleUsesStrings ? "imapEnterPasswordPrompt" : "5047",
                     "%S", null, null, true);
-                LoadDialogData(this._localMsgsBundle, "pop3", "pop3EnterPasswordPromptTitle",
+                LoadDialogData(this._localMsgsBundle, "pop", "pop3EnterPasswordPromptTitle",
                     "pop3EnterPasswordPrompt", "%2$S", null, "%1$S");
                 LoadDialogData(this._newsBundle, "nntp-1", "enterUserPassTitle",
                     "enterUserPassServer", "%S");


### PR DESCRIPTION
We might save this one for 1.6/2.0 if you are going to make some breaking changes then.

This will only break people that have exact URL matching enabled.
