### PR TITLE
dispatch change event after filling form field

### DIFF
--- a/Firefox addon/KeeFox/chrome/content/framescript/formsFillTab.js
+++ b/Firefox addon/KeeFox/chrome/content/framescript/formsFillTab.js
@@ -168,6 +168,8 @@ var _fillASingleField = function (domElement, fieldType, value)
     {    
         domElement.value = value; 
     }
+
+    domElement.dispatchEvent(new content.UIEvent('change', {view: content, bubbles: true, cancelable: true}));
 }
 
 var _fillManyFormFields = function 


### PR DESCRIPTION
This change fixes #638 and is a duplicate of #739, but with white-space changes removed.