### PR TITLE
Manually dispatch a change event after updating a field

### DIFF
--- a/Firefox addon/KeeFox/chrome/content/framescript/formsFillTab.js
+++ b/Firefox addon/KeeFox/chrome/content/framescript/formsFillTab.js
@@ -168,6 +168,8 @@ var _fillASingleField = function (domElement, fieldType, value)
     {    
         domElement.value = value; 
     }
+
+    domElement.dispatchEvent(new content.UIEvent('change', {view: content, bubbles: true, cancelable: true}));
 }
 
 var _fillManyFormFields = function 


### PR DESCRIPTION
Re-submitting without whitespace changes in case you change your mind and decide to include this line in 1.7.