### PR TITLE
Add dialog matching for EnterLoginForProxy3

### DIFF
--- a/Firefox addon/KeeFox/chrome/content/commonDialog.js
+++ b/Firefox addon/KeeFox/chrome/content/commonDialog.js
@@ -444,17 +444,24 @@ var keeFoxDialogManager = {
                 var currentProxyL10nPattern = "";            
                 try 
                 {
+                    // Name changed again in Firefox 50 or so
+                    currentProxyL10nPattern = this._cdBundle.GetStringFromName("EnterLoginForProxy3");
+                } catch (exception)
+                {
                     try 
                     {
                         // Name changed in Firefox 49
                         currentProxyL10nPattern = this._cdBundle.GetStringFromName("EnterLoginForProxy2");
                     } catch (exception)
                     {
-                        currentProxyL10nPattern = this._cdBundle.GetStringFromName("EnterLoginForProxy");
+                        try
+                        {
+                            currentProxyL10nPattern = this._cdBundle.GetStringFromName("EnterLoginForProxy");
+                        } catch (exception)
+                        {
+                            currentProxyL10nPattern = this._promptBundle.GetStringFromName("EnterLoginForProxy");
+                        }
                     }
-                } catch (exception)
-                {
-                    currentProxyL10nPattern = this._promptBundle.GetStringFromName("EnterLoginForProxy");
                 }
 
                 realmFirst = false;


### PR DESCRIPTION
This adds password dialog matching for EnterLoginForProxy3, which was
introduced somewhere around Firefox 50. Also rearranged the checks for
older versions in a more logical order.

Fixes #748