### PR TITLE
dispatch change/input event after filling form field (optional)

### DIFF
--- a/Firefox addon/KeeFox/chrome/content/framescript/formsFillTab.js
+++ b/Firefox addon/KeeFox/chrome/content/framescript/formsFillTab.js
@@ -168,6 +168,12 @@ var _fillASingleField = function (domElement, fieldType, value)
     {    
         domElement.value = value; 
     }
+
+    if (KFExtension.prefs.getValue("triggerChangeInputEventAfterFill", false)) {
+        Logger.debug("Trigger Change/Input events.");
+        domElement.dispatchEvent(new content.UIEvent('change', {view: content, bubbles: true, cancelable: true}));
+        domElement.dispatchEvent(new content.UIEvent('input', {view: content, bubbles: true, cancelable: true}));
+    }
 }
 
 var _fillManyFormFields = function 

--- a/Firefox addon/KeeFox/chrome/content/options.js
+++ b/Firefox addon/KeeFox/chrome/content/options.js
@@ -13,7 +13,7 @@ function onLoad(){
           'when-keefox-chooses-standard-form', 'mi-FillForm', 'mi-FillAndSubmitForm',
           'mi-do-nothing', 'mi-FillForm2', 'mi-FillAndSubmitForm2',
       'mi-do-nothing2', 'mi-FillForm3', 'mi-FillAndSubmitForm3', 'desc-fill-note',
-      'check-autoFillFormsWithMultipleMatches', 'check-searchAllOpenDBs', 'check-listAllOpenDBs', 'check-alwaysDisplayUsernameWhenTitleIsShown', 'check-notifyWhenLateDiscovery',
+      'check-autoFillFormsWithMultipleMatches', 'check-triggerChangeInputEventAfterFill', 'check-searchAllOpenDBs', 'check-listAllOpenDBs', 'check-alwaysDisplayUsernameWhenTitleIsShown', 'check-notifyWhenLateDiscovery',
       'notifyBarRequestPasswordSave','desc-exclude-saved-sites','excludedSitesRemoveButton','notifyWhenLoggedOut',
       'famsOptionsButton','desc-log-method','check-log-method-console','check-log-method-stdout','check-log-method-file',
       'desc-log-level','KeeFox-pref-logLevel-debug','KeeFox-pref-logLevel-info','KeeFox-pref-logLevel-warn','KeeFox-pref-logLevel-error',

--- a/Firefox addon/KeeFox/chrome/content/options.xul
+++ b/Firefox addon/KeeFox/chrome/content/options.xul
@@ -45,6 +45,7 @@
       <preference id="KeeFox-pref-autoFillDialogs" name="extensions.keefox@chris.tomlinson.autoFillDialogs" type="bool"/>
       <preference id="KeeFox-pref-autoSubmitDialogs" name="extensions.keefox@chris.tomlinson.autoSubmitDialogs" type="bool"/>
       <preference id="KeeFox-pref-autoFillFormsWithMultipleMatches" name="extensions.keefox@chris.tomlinson.autoFillFormsWithMultipleMatches" type="bool"/>
+      <preference id="KeeFox-pref-triggerChangeInputEventAfterFill" name="extensions.keefox@chris.tomlinson.triggerChangeInputEventAfterFill" type="bool"/>
       <preference id="KeeFox-pref-searchAllOpenDBs" name="extensions.keefox@chris.tomlinson.searchAllOpenDBs" type="bool"/>
       <preference id="KeeFox-pref-listAllOpenDBs" name="extensions.keefox@chris.tomlinson.listAllOpenDBs" type="bool"/>
       <preference id="KeeFox-pref-alwaysDisplayUsernameWhenTitleIsShown" name="extensions.keefox@chris.tomlinson.alwaysDisplayUsernameWhenTitleIsShown" type="bool"/>
@@ -159,6 +160,8 @@
             <description id="desc-fill-note" class="itemEnd note">%-KeeFox-pref-FillNote.desc-%</description>
 
             <checkbox id="check-autoFillFormsWithMultipleMatches" preference="KeeFox-pref-autoFillFormsWithMultipleMatches" label="%-KeeFox-pref-autoFillFormsWithMultipleMatches.label-%" />
+
+            <checkbox id="check-triggerChangeInputEventAfterFill" preference="KeeFox-pref-triggerChangeInputEventAfterFill" label="%-KeeFox-pref-triggerChangeInputEventAfterFill.label-%" />
 
           </vbox>
         </tabpanel>

--- a/Firefox addon/KeeFox/chrome/locale/en-US/keefox.properties
+++ b/Firefox addon/KeeFox/chrome/locale/en-US/keefox.properties
@@ -122,6 +122,7 @@ KeeFox-pref-site-options-savepass.desc=Disable "save password" notifications in
 KeeFox-pref-when-keefox-chooses-prompt.desc= When KeeFox chooses a matching login for an HTTPAuth, NTLM or proxy prompt, KeeFox should
 KeeFox-pref-when-keefox-chooses-standard-form.desc= When KeeFox chooses a matching login for a standard form, KeeFox should
 KeeFox-pref-when-user-chooses.desc= When you choose a matched login, KeeFox should
+KeeFox-pref-triggerChangeInputEventAfterFill.label= Trigger Change/Input Event after auto-fill
 KeeFox-remove-site=Remove Site
 KeeFox-save-site-settings=Save site settings
 KeeFox-site-options-default-intro.desc=Settings for all sites. Add individual site addresses to override.

--- a/Firefox addon/KeeFox/defaults/preferences/prefs.js
+++ b/Firefox addon/KeeFox/defaults/preferences/prefs.js
@@ -26,3 +26,4 @@ pref("extensions.keefox@chris.tomlinson.tabResultsCacheEnabled", true);
 pref("extensions.keefox@chris.tomlinson.rememberMRUGroup", true);
 pref("extensions.keefox@chris.tomlinson.notifyWhenEntryUpdated", true);
 pref("extensions.keefox@chris.tomlinson.notifyWhenLateDiscovery", true);
+pref("extensions.keefox@chris.tomlinson.triggerChangeInputEventAfterFill", false);

--- a/Firefox addon/KeeFox/modules/DataMigration.js
+++ b/Firefox addon/KeeFox/modules/DataMigration.js
@@ -74,6 +74,7 @@ var DataMigration = {
         fullConfig.saveFavicons = KFExtension.prefs.getValue("saveFavicons", true);
         fullConfig.searchAllOpenDBs = KFExtension.prefs.getValue("searchAllOpenDBs", true);
         fullConfig.tutorialProgress = KFExtension.prefs.getValue("tutorialProgress", "");
+        fullConfig.triggerChangeInputEventAfterFill = KFExtension.prefs.getValue("triggerChangeInputEventAfterFill", false);
         fullConfig.config = keefox_org.config.current;
 
         webExtensionPort.postMessage(fullConfig);


### PR DESCRIPTION
This fixes #638, but has it as a configurable option, off by default, as suggested in #771 
